### PR TITLE
Provide string substitution for links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ package-lock.json
 .direnv
 .envrc
 result
+seed.json

--- a/db.go
+++ b/db.go
@@ -20,11 +20,11 @@ import (
 
 // Link is the structure stored for each go short link.
 type Link struct {
-	Short    string // the "foo" part of http://go/foo
-	Long     string // the target URL or text/template pattern to run
-	Created  time.Time
-	LastEdit time.Time // when the link was last edited
-	Owner    string    // user@domain
+	Short    string    `json:"short"` // the "foo" part of http://go/foo
+	Long     string    `json:"long"`  // the target URL or text/template pattern to run
+	Created  time.Time `json:"created"`
+	LastEdit time.Time `json:"last_edit"` // when the link was last edited
+	Owner    string    `json:"owner"`     // user@domain
 }
 
 // ClickStats is the number of clicks a set of links have received in a given

--- a/golink.go
+++ b/golink.go
@@ -676,6 +676,9 @@ func expandLink(long string, env expandEnv) (*url.URL, error) {
 			panic("malformed query string")
 		}
 
+		// Here, we detect if the original URL contains a pattern of @${key}@. If so,
+		// we substitute it and remove it from the query params to be passed on.
+		// Otherwise we ignore it in this iterator.
 		pattern := fmt.Sprintf("@%s@", regexp.QuoteMeta(key))
 		re := regexp.MustCompile(pattern)
 

--- a/golink.go
+++ b/golink.go
@@ -52,6 +52,8 @@ const (
 	//
 	// [Fetch Spec]: https://fetch.spec.whatwg.org
 	secHeaderName = "Sec-Golink"
+
+	postHogTemplateString = "https://us.posthog.com/project/59410/events#q=%7B%22kind%22%3A%22DataTableNode%22%2C%22full%22%3Atrue%2C%22source%22%3A%7B%22kind%22%3A%22EventsQuery%22%2C%22select%22%3A%5B%22*%22%2C%22event%22%2C%22person%22%2C%22coalesce(properties.%24current_url%2C%20properties.%24screen_name)%20--%20Url%20%2F%20Screen%22%2C%22properties.%24lib%22%2C%22timestamp%22%2C%22properties.ingestion_project%22%2C%22properties.status%22%5D%2C%22orderBy%22%3A%5B%22timestamp%20DESC%22%5D%2C%22after%22%3A%222024-04-17T09%3A07%3A09.000Z%22%2C%22properties%22%3A%5B%7B%22key%22%3A%22%24window_id%22%2C%22value%22%3A%5B%22@window_id@%22%5D%2C%22operator%22%3A%22exact%22%2C%22type%22%3A%22event%22%7D%5D%2C%22before%22%3A%222024-04-17T09%3A07%3A11.000Z%22%7D%2C%22propertiesViaUrl%22%3Atrue%2C%22showSavedQueries%22%3Atrue%2C%22showPersistentColumnConfigurator%22%3Atrue%7D"
 )
 
 var (
@@ -121,7 +123,7 @@ func Run() error {
 
 	seedLink := &Link{
 		Short:    "ph-wid",
-		Long:     "https://us.posthog.com/project/59410/events#q=%7B%22kind%22%3A%22DataTableNode%22%2C%22full%22%3Atrue%2C%22source%22%3A%7B%22kind%22%3A%22EventsQuery%22%2C%22select%22%3A%5B%22*%22%2C%22event%22%2C%22person%22%2C%22coalesce(properties.%24current_url%2C%20properties.%24screen_name)%20--%20Url%20%2F%20Screen%22%2C%22properties.%24lib%22%2C%22timestamp%22%2C%22properties.ingestion_project%22%2C%22properties.status%22%5D%2C%22orderBy%22%3A%5B%22timestamp%20DESC%22%5D%2C%22after%22%3A%222024-04-17T09%3A07%3A09.000Z%22%2C%22properties%22%3A%5B%7B%22key%22%3A%22%24window_id%22%2C%22value%22%3A%5B%22@window_id@%22%5D%2C%22operator%22%3A%22exact%22%2C%22type%22%3A%22event%22%7D%5D%2C%22before%22%3A%222024-04-17T09%3A07%3A11.000Z%22%7D%2C%22propertiesViaUrl%22%3Atrue%2C%22showSavedQueries%22%3Atrue%2C%22showPersistentColumnConfigurator%22%3Atrue%7D",
+		Long:     postHogTemplateString,
 		Created:  time.Now(),
 		LastEdit: time.Now(),
 		Owner:    "detsys",

--- a/golink.go
+++ b/golink.go
@@ -679,15 +679,12 @@ func expandLink(long string, env expandEnv) (*url.URL, error) {
 		// Here, we detect if the original URL contains a pattern of @${key}@. If so,
 		// we substitute it and remove it from the query params to be passed on.
 		// Otherwise we ignore it in this iterator.
-		pattern := fmt.Sprintf("@%s@", regexp.QuoteMeta(key))
-		re := regexp.MustCompile(pattern)
+		pattern := fmt.Sprintf("@%s@", key)
 
-		if re.MatchString(long) {
+		if strings.Contains(long, pattern) {
 			env.query.Del(key)
 
-			replaceKey := fmt.Sprintf("@%s@", key)
-
-			long = strings.Replace(long, replaceKey, values[0], -1)
+			long = strings.Replace(long, pattern, values[0], -1)
 		}
 	}
 

--- a/golink.go
+++ b/golink.go
@@ -641,15 +641,10 @@ func (e expandEnv) User() (string, error) {
 	return e.user, nil
 }
 
-func templateReplace(long string) string {
-	return long
-}
-
 var expandFuncMap = texttemplate.FuncMap{
-	"PathEscape":      url.PathEscape,
-	"QueryEscape":     url.QueryEscape,
-	"TrimSuffix":      strings.TrimSuffix,
-	"TemplateReplace": templateReplace,
+	"PathEscape":  url.PathEscape,
+	"QueryEscape": url.QueryEscape,
+	"TrimSuffix":  strings.TrimSuffix,
 }
 
 // expandLink returns the expanded long URL to redirect to, executing any

--- a/golink.go
+++ b/golink.go
@@ -668,23 +668,22 @@ func expandLink(long string, env expandEnv) (*url.URL, error) {
 	// https://example.com/replaced if thing=replaced is supplied as a query
 	// param.
 	for key, values := range env.query {
-		// This should never happen in a query string, as even when
-		// you have foo=&bar=baz, foo is parsed as []string{""}. But
-		// we should panic with a message if we encounter some edge
-		// case we're not aware of.
-		if len(values) == 0 {
-			panic("malformed query string")
-		}
-
 		// Here, we detect if the original URL contains a pattern of @${key}@. If so,
 		// we substitute it and remove it from the query params to be passed on.
 		// Otherwise we ignore it in this iterator.
 		pattern := fmt.Sprintf("@%s@", key)
 
 		if strings.Contains(long, pattern) {
+			// If subsitution is happening, removing the param from those to be passed
+			// on to the final URL
 			env.query.Del(key)
 
-			long = strings.Replace(long, pattern, values[0], -1)
+			// Here, we perform the substitution for each value of the param.
+			// In general, we should avoid substitutions with multiple values like
+			// foo=bar,baz, as baz here would have no effect.
+			for _, value := range values {
+				long = strings.Replace(long, pattern, value, -1)
+			}
 		}
 	}
 

--- a/golink.go
+++ b/golink.go
@@ -691,15 +691,7 @@ func expandLink(long string, env expandEnv) (*url.URL, error) {
 		query := u.Query()
 		for key, values := range env.query {
 			for _, v := range values {
-				if key == "window_id" {
-					windowIdEncoded := url.QueryEscape(v)
-
-					value := "%7B%22kind%22%3A%22DataTableNode%22%2C%22full%22%3Atrue%2C%22source%22%3A%7B%22kind%22%3A%22EventsQuery%22%2C%22select%22%3A%5B%22*%22%2C%22event%22%2C%22person%22%2C%22coalesce(properties.%24current_url%2C%20properties.%24screen_name)%20--%20Url%20%2F%20Screen%22%2C%22properties.%24lib%22%2C%22timestamp%22%2C%22properties.ingestion_project%22%2C%22properties.status%22%5D%2C%22orderBy%22%3A%5B%22timestamp%20DESC%22%5D%2C%22after%22%3A%222024-04-17T09%3A07%3A09.000Z%22%2C%22properties%22%3A%5B%7B%22key%22%3A%22%24window_id%22%2C%22value%22%3A%5B%22" + windowIdEncoded + "%22%5D%2C%22operator%22%3A%22exact%22%2C%22type%22%3A%22event%22%7D%5D%2C%22before%22%3A%222024-04-17T09%3A07%3A11.000Z%22%7D%2C%22propertiesViaUrl%22%3Atrue%2C%22showSavedQueries%22%3Atrue%2C%22showPersistentColumnConfigurator%22%3Atrue%7D"
-
-					query.Add("q", value)
-				} else {
-					query.Add(key, v)
-				}
+				query.Add(key, v)
 			}
 		}
 		u.RawQuery = query.Encode()

--- a/golink.go
+++ b/golink.go
@@ -52,8 +52,6 @@ const (
 	//
 	// [Fetch Spec]: https://fetch.spec.whatwg.org
 	secHeaderName = "Sec-Golink"
-
-	postHogTemplateString = "https://us.posthog.com/project/59410/events#q=%7B%22kind%22%3A%22DataTableNode%22%2C%22full%22%3Atrue%2C%22source%22%3A%7B%22kind%22%3A%22EventsQuery%22%2C%22select%22%3A%5B%22*%22%2C%22event%22%2C%22person%22%2C%22coalesce(properties.%24current_url%2C%20properties.%24screen_name)%20--%20Url%20%2F%20Screen%22%2C%22properties.%24lib%22%2C%22timestamp%22%2C%22properties.ingestion_project%22%2C%22properties.status%22%5D%2C%22orderBy%22%3A%5B%22timestamp%20DESC%22%5D%2C%22after%22%3A%222024-04-17T09%3A07%3A09.000Z%22%2C%22properties%22%3A%5B%7B%22key%22%3A%22%24window_id%22%2C%22value%22%3A%5B%22@window_id@%22%5D%2C%22operator%22%3A%22exact%22%2C%22type%22%3A%22event%22%7D%5D%2C%22before%22%3A%222024-04-17T09%3A07%3A11.000Z%22%7D%2C%22propertiesViaUrl%22%3Atrue%2C%22showSavedQueries%22%3Atrue%2C%22showPersistentColumnConfigurator%22%3Atrue%7D"
 )
 
 var (
@@ -66,14 +64,7 @@ var (
 	hostname          = flag.String("hostname", defaultHostname, "service name")
 	resolveFromBackup = flag.String("resolve-from-backup", "", "resolve a link from snapshot file and exit")
 	allowUnknownUsers = flag.Bool("allow-unknown-users", false, "allow unknown users to save links")
-
-	postHogLink = &Link{
-		Short:    "ph-wid",
-		Long:     postHogTemplateString,
-		Created:  time.Now(),
-		LastEdit: time.Now(),
-		Owner:    "detsys",
-	}
+	seedJsonPath      = flag.String("seed-json-path", "", "path to a seed JSON file")
 )
 
 var stats struct {
@@ -129,9 +120,25 @@ func Run() error {
 		return fmt.Errorf("NewSQLiteDB(%q): %w", *sqlitefile, err)
 	}
 
-	log.Println("adding /ph-wid seed link to database")
-	if err := db.Save(postHogLink); err != nil {
-		log.Fatal("failed to add seed link")
+	if *seedJsonPath != "" {
+		log.Printf("seeding the db with json from %s", *seedJsonPath)
+
+		jsonFile, err := os.ReadFile(*seedJsonPath)
+		if err != nil {
+			return fmt.Errorf("failed to load seed json: %v", err)
+		}
+
+		var seedJson seedJson
+		if err := json.Unmarshal(jsonFile, &seedJson); err != nil {
+			return fmt.Errorf("failed to parse seed json: %v", err)
+		}
+
+		for _, link := range seedJson.Links {
+			log.Printf("adding seed link with short %s\n", link.Short)
+			if err := db.Save(&link); err != nil {
+				log.Fatal("failed to add seed link")
+			}
+		}
 	}
 
 	if *snapshot != "" {
@@ -295,6 +302,10 @@ type deleteData struct {
 	Short string
 	Long  string
 	XSRF  string
+}
+
+type seedJson struct {
+	Links []Link `json:"links"`
 }
 
 var xsrfKey string

--- a/golink.go
+++ b/golink.go
@@ -543,6 +543,9 @@ func serveGo(w http.ResponseWriter, r *http.Request) {
 
 	var target *url.URL
 
+	// We need to treat the PostHog URLs as a completely different species here because they
+	// don't use query params in a standard way. Standard URLs have this structure: https://example.com?foo=bar.
+	// But PostHog uses # as a kind makeshift separator, which forces us to treat the entire URL as the base URL.
 	if link.Short == "ph-wid" {
 		windowId := env.query.Get("window_id")
 		if windowId == "" {

--- a/golink.go
+++ b/golink.go
@@ -119,6 +119,18 @@ func Run() error {
 		return fmt.Errorf("NewSQLiteDB(%q): %w", *sqlitefile, err)
 	}
 
+	seedLink := &Link{
+		Short:    "ph-wid",
+		Long:     "https://us.posthog.com/project/59410/events#q=%7B%22kind%22%3A%22DataTableNode%22%2C%22full%22%3Atrue%2C%22source%22%3A%7B%22kind%22%3A%22EventsQuery%22%2C%22select%22%3A%5B%22*%22%2C%22event%22%2C%22person%22%2C%22coalesce(properties.%24current_url%2C%20properties.%24screen_name)%20--%20Url%20%2F%20Screen%22%2C%22properties.%24lib%22%2C%22timestamp%22%2C%22properties.ingestion_project%22%2C%22properties.status%22%5D%2C%22orderBy%22%3A%5B%22timestamp%20DESC%22%5D%2C%22after%22%3A%222024-04-17T09%3A07%3A09.000Z%22%2C%22properties%22%3A%5B%7B%22key%22%3A%22%24window_id%22%2C%22value%22%3A%5B%22@window_id@%22%5D%2C%22operator%22%3A%22exact%22%2C%22type%22%3A%22event%22%7D%5D%2C%22before%22%3A%222024-04-17T09%3A07%3A11.000Z%22%7D%2C%22propertiesViaUrl%22%3Atrue%2C%22showSavedQueries%22%3Atrue%2C%22showPersistentColumnConfigurator%22%3Atrue%7D",
+		Created:  time.Now(),
+		LastEdit: time.Now(),
+		Owner:    "detsys",
+	}
+
+	if err := db.Save(seedLink); err != nil {
+		log.Fatal("failed to add seed link")
+	}
+
 	if *snapshot != "" {
 		if LastSnapshot != nil {
 			log.Printf("LastSnapshot already set; ignoring --snapshot")
@@ -663,6 +675,7 @@ func expandLink(long string, env expandEnv) (*url.URL, error) {
 	if len(env.query) > 0 {
 		query := u.Query()
 		for key, values := range env.query {
+			log.Printf("%s: %v", key, values)
 			for _, v := range values {
 				query.Add(key, v)
 			}

--- a/golink.go
+++ b/golink.go
@@ -127,6 +127,7 @@ func Run() error {
 		Owner:    "detsys",
 	}
 
+	log.Println("adding /ph-wid seed link to database")
 	if err := db.Save(seedLink); err != nil {
 		log.Fatal("failed to add seed link")
 	}
@@ -537,7 +538,21 @@ func serveGo(w http.ResponseWriter, r *http.Request) {
 
 	cu, _ := currentUser(r)
 	env := expandEnv{Now: time.Now().UTC(), Path: remainder, user: cu.login, query: r.URL.Query()}
-	target, err := expandLink(link.Long, env)
+
+	var target *url.URL
+
+	if link.Short == "ph-wid" {
+		windowId := env.query.Get("window_id")
+		if windowId == "" {
+			http.Error(w, "no window id supplied", http.StatusBadRequest)
+		}
+		windowIdEncoded := url.QueryEscape(windowId)
+		linkLong := strings.Replace(link.Long, "@window_id@", windowIdEncoded, -1)
+		target, err = url.Parse(linkLong)
+	} else {
+		target, err = expandLink(link.Long, env)
+	}
+
 	if err != nil {
 		log.Printf("expanding %q: %v", link.Long, err)
 		if errors.Is(err, errNoUser) {
@@ -675,9 +690,16 @@ func expandLink(long string, env expandEnv) (*url.URL, error) {
 	if len(env.query) > 0 {
 		query := u.Query()
 		for key, values := range env.query {
-			log.Printf("%s: %v", key, values)
 			for _, v := range values {
-				query.Add(key, v)
+				if key == "window_id" {
+					windowIdEncoded := url.QueryEscape(v)
+
+					value := "%7B%22kind%22%3A%22DataTableNode%22%2C%22full%22%3Atrue%2C%22source%22%3A%7B%22kind%22%3A%22EventsQuery%22%2C%22select%22%3A%5B%22*%22%2C%22event%22%2C%22person%22%2C%22coalesce(properties.%24current_url%2C%20properties.%24screen_name)%20--%20Url%20%2F%20Screen%22%2C%22properties.%24lib%22%2C%22timestamp%22%2C%22properties.ingestion_project%22%2C%22properties.status%22%5D%2C%22orderBy%22%3A%5B%22timestamp%20DESC%22%5D%2C%22after%22%3A%222024-04-17T09%3A07%3A09.000Z%22%2C%22properties%22%3A%5B%7B%22key%22%3A%22%24window_id%22%2C%22value%22%3A%5B%22" + windowIdEncoded + "%22%5D%2C%22operator%22%3A%22exact%22%2C%22type%22%3A%22event%22%7D%5D%2C%22before%22%3A%222024-04-17T09%3A07%3A11.000Z%22%7D%2C%22propertiesViaUrl%22%3Atrue%2C%22showSavedQueries%22%3Atrue%2C%22showPersistentColumnConfigurator%22%3Atrue%7D"
+
+					query.Add("q", value)
+				} else {
+					query.Add(key, v)
+				}
 			}
 		}
 		u.RawQuery = query.Encode()

--- a/golink_test.go
+++ b/golink_test.go
@@ -30,6 +30,7 @@ func TestServeGo(t *testing.T) {
 	db.Save(&Link{Short: "who", Long: "http://who/"})
 	db.Save(&Link{Short: "me", Long: "/who/{{.User}}"})
 	db.Save(&Link{Short: "invalid-var", Long: "/who/{{.Invalid}}"})
+	db.Save(&Link{Short: "substitutable", Long: "https://example.com/@replace_me@"})
 
 	tests := []struct {
 		name        string
@@ -96,6 +97,18 @@ func TestServeGo(t *testing.T) {
 			link:        "/me",
 			currentUser: func(*http.Request) (user, error) { return user{}, nil },
 			wantStatus:  http.StatusUnauthorized,
+		},
+		{
+			name:       "apply substitute",
+			link:       "/substitutable?replace_me=foo",
+			wantStatus: http.StatusFound,
+			wantLink:   "https://example.com/foo",
+		},
+		{
+			name:       "apply substitute and pass through other params",
+			link:       "/substitutable?baq=baz&foo=bar&replace_me=something",
+			wantStatus: http.StatusFound,
+			wantLink:   "https://example.com/something?baq=baz&foo=bar",
 		},
 	}
 

--- a/golink_test.go
+++ b/golink_test.go
@@ -30,7 +30,6 @@ func TestServeGo(t *testing.T) {
 	db.Save(&Link{Short: "who", Long: "http://who/"})
 	db.Save(&Link{Short: "me", Long: "/who/{{.User}}"})
 	db.Save(&Link{Short: "invalid-var", Long: "/who/{{.Invalid}}"})
-	db.Save(postHogLink)
 
 	tests := []struct {
 		name        string
@@ -97,24 +96,6 @@ func TestServeGo(t *testing.T) {
 			link:        "/me",
 			currentUser: func(*http.Request) (user, error) { return user{}, nil },
 			wantStatus:  http.StatusUnauthorized,
-		},
-		{
-			name:       "posthog link with no supplied window id",
-			link:       "/ph-wid",
-			wantStatus: http.StatusFound,
-			wantLink:   postHogTemplateString,
-		},
-		{
-			name:       "posthog link with silly window id",
-			link:       "/ph-wid?window_id=foo",
-			wantStatus: http.StatusFound,
-			wantLink:   "https://us.posthog.com/project/59410/events#q=%7B%22kind%22%3A%22DataTableNode%22%2C%22full%22%3Atrue%2C%22source%22%3A%7B%22kind%22%3A%22EventsQuery%22%2C%22select%22%3A%5B%22*%22%2C%22event%22%2C%22person%22%2C%22coalesce(properties.%24current_url%2C%20properties.%24screen_name)%20--%20Url%20%2F%20Screen%22%2C%22properties.%24lib%22%2C%22timestamp%22%2C%22properties.ingestion_project%22%2C%22properties.status%22%5D%2C%22orderBy%22%3A%5B%22timestamp%20DESC%22%5D%2C%22after%22%3A%222024-04-17T09%3A07%3A09.000Z%22%2C%22properties%22%3A%5B%7B%22key%22%3A%22%24window_id%22%2C%22value%22%3A%5B%22foo%22%5D%2C%22operator%22%3A%22exact%22%2C%22type%22%3A%22event%22%7D%5D%2C%22before%22%3A%222024-04-17T09%3A07%3A11.000Z%22%7D%2C%22propertiesViaUrl%22%3Atrue%2C%22showSavedQueries%22%3Atrue%2C%22showPersistentColumnConfigurator%22%3Atrue%7D",
-		},
-		{
-			name:       "posthog link with realistic window id",
-			link:       "/ph-wid?window_id=GHWJA-2430d9ca0d15845965b22c53ca98e1a06b8e4e4ca932d87189e218bb012d1a80",
-			wantStatus: http.StatusFound,
-			wantLink:   "https://us.posthog.com/project/59410/events#q=%7B%22kind%22%3A%22DataTableNode%22%2C%22full%22%3Atrue%2C%22source%22%3A%7B%22kind%22%3A%22EventsQuery%22%2C%22select%22%3A%5B%22*%22%2C%22event%22%2C%22person%22%2C%22coalesce(properties.%24current_url%2C%20properties.%24screen_name)%20--%20Url%20%2F%20Screen%22%2C%22properties.%24lib%22%2C%22timestamp%22%2C%22properties.ingestion_project%22%2C%22properties.status%22%5D%2C%22orderBy%22%3A%5B%22timestamp%20DESC%22%5D%2C%22after%22%3A%222024-04-17T09%3A07%3A09.000Z%22%2C%22properties%22%3A%5B%7B%22key%22%3A%22%24window_id%22%2C%22value%22%3A%5B%22GHWJA-2430d9ca0d15845965b22c53ca98e1a06b8e4e4ca932d87189e218bb012d1a80%22%5D%2C%22operator%22%3A%22exact%22%2C%22type%22%3A%22event%22%7D%5D%2C%22before%22%3A%222024-04-17T09%3A07%3A11.000Z%22%7D%2C%22propertiesViaUrl%22%3Atrue%2C%22showSavedQueries%22%3Atrue%2C%22showPersistentColumnConfigurator%22%3Atrue%7D",
 		},
 	}
 

--- a/golink_test.go
+++ b/golink_test.go
@@ -30,6 +30,7 @@ func TestServeGo(t *testing.T) {
 	db.Save(&Link{Short: "who", Long: "http://who/"})
 	db.Save(&Link{Short: "me", Long: "/who/{{.User}}"})
 	db.Save(&Link{Short: "invalid-var", Long: "/who/{{.Invalid}}"})
+	db.Save(postHogLink)
 
 	tests := []struct {
 		name        string
@@ -96,6 +97,24 @@ func TestServeGo(t *testing.T) {
 			link:        "/me",
 			currentUser: func(*http.Request) (user, error) { return user{}, nil },
 			wantStatus:  http.StatusUnauthorized,
+		},
+		{
+			name:       "posthog link with no supplied window id",
+			link:       "/ph-wid",
+			wantStatus: http.StatusFound,
+			wantLink:   postHogTemplateString,
+		},
+		{
+			name:       "posthog link with silly window id",
+			link:       "/ph-wid?window_id=foo",
+			wantStatus: http.StatusFound,
+			wantLink:   "https://us.posthog.com/project/59410/events#q=%7B%22kind%22%3A%22DataTableNode%22%2C%22full%22%3Atrue%2C%22source%22%3A%7B%22kind%22%3A%22EventsQuery%22%2C%22select%22%3A%5B%22*%22%2C%22event%22%2C%22person%22%2C%22coalesce(properties.%24current_url%2C%20properties.%24screen_name)%20--%20Url%20%2F%20Screen%22%2C%22properties.%24lib%22%2C%22timestamp%22%2C%22properties.ingestion_project%22%2C%22properties.status%22%5D%2C%22orderBy%22%3A%5B%22timestamp%20DESC%22%5D%2C%22after%22%3A%222024-04-17T09%3A07%3A09.000Z%22%2C%22properties%22%3A%5B%7B%22key%22%3A%22%24window_id%22%2C%22value%22%3A%5B%22foo%22%5D%2C%22operator%22%3A%22exact%22%2C%22type%22%3A%22event%22%7D%5D%2C%22before%22%3A%222024-04-17T09%3A07%3A11.000Z%22%7D%2C%22propertiesViaUrl%22%3Atrue%2C%22showSavedQueries%22%3Atrue%2C%22showPersistentColumnConfigurator%22%3Atrue%7D",
+		},
+		{
+			name:       "posthog link with realistic window id",
+			link:       "/ph-wid?window_id=GHWJA-2430d9ca0d15845965b22c53ca98e1a06b8e4e4ca932d87189e218bb012d1a80",
+			wantStatus: http.StatusFound,
+			wantLink:   "https://us.posthog.com/project/59410/events#q=%7B%22kind%22%3A%22DataTableNode%22%2C%22full%22%3Atrue%2C%22source%22%3A%7B%22kind%22%3A%22EventsQuery%22%2C%22select%22%3A%5B%22*%22%2C%22event%22%2C%22person%22%2C%22coalesce(properties.%24current_url%2C%20properties.%24screen_name)%20--%20Url%20%2F%20Screen%22%2C%22properties.%24lib%22%2C%22timestamp%22%2C%22properties.ingestion_project%22%2C%22properties.status%22%5D%2C%22orderBy%22%3A%5B%22timestamp%20DESC%22%5D%2C%22after%22%3A%222024-04-17T09%3A07%3A09.000Z%22%2C%22properties%22%3A%5B%7B%22key%22%3A%22%24window_id%22%2C%22value%22%3A%5B%22GHWJA-2430d9ca0d15845965b22c53ca98e1a06b8e4e4ca932d87189e218bb012d1a80%22%5D%2C%22operator%22%3A%22exact%22%2C%22type%22%3A%22event%22%7D%5D%2C%22before%22%3A%222024-04-17T09%3A07%3A11.000Z%22%7D%2C%22propertiesViaUrl%22%3Atrue%2C%22showSavedQueries%22%3Atrue%2C%22showPersistentColumnConfigurator%22%3Atrue%7D",
 		},
 	}
 


### PR DESCRIPTION
To try this out locally, start the server:

```bash
# create a seed.json file
echo '{"links":[{"short":"ph-wid","long": "https://us.posthog.com/project/59410/events#q=%7B%22kind%22%3A%22DataTableNode%22%2C%22full%22%3Atrue%2C%22source%22%3A%7B%22kind%22%3A%22EventsQuery%22%2C%22select%22%3A%5B%22*%22%2C%22event%22%2C%22person%22%2C%22coalesce(properties.%24current_url%2C%20properties.%24screen_name)%20--%20Url%20%2F%20Screen%22%2C%22properties.%24lib%22%2C%22timestamp%22%2C%22properties.ingestion_project%22%2C%22properties.status%22%5D%2C%22orderBy%22%3A%5B%22timestamp%20DESC%22%5D%2C%22after%22%3A%222024-04-17T09%3A07%3A09.000Z%22%2C%22properties%22%3A%5B%7B%22key%22%3A%22%24window_id%22%2C%22value%22%3A%5B%22@window_id@%22%5D%2C%22operator%22%3A%22exact%22%2C%22type%22%3A%22event%22%7D%5D%2C%22before%22%3A%222024-04-17T09%3A07%3A11.000Z%22%7D%2C%22propertiesViaUrl%22%3Atrue%2C%22showSavedQueries%22%3Atrue%2C%22showPersistentColumnConfigurator%22%3Atrue%7D"}]}' > seed.json

# start the server
GOLINK_SEED_JSON="$(cat ./seed.json)" go run ./cmd/golink -dev-listen :8080
```

Then get a link:

```bash
curl -I "http://localhost:8080/ph-wid?window_id=GHWJA-2430d9ca0d15845965b22c53ca98e1a06b8e4e4ca932d87189e218bb012d1a92"
```

Or go to [this link](http://localhost:8080/ph-wid?window_id=GHWJA-2430d9ca0d15845965b22c53ca98e1a06b8e4e4ca932d87189e218bb012d1a92) in your browser to get automatically redirected.